### PR TITLE
Fixed urllib dependency conflict.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+certifi==2021.5.30
+chardet==3.0.4
+idna==2.10
 pick==1.0.0
 requests==2.24.0
 requests-toolbelt==0.9.1
-urllib3>=1.26.5
+urllib3==1.26.6


### PR DESCRIPTION
I got an error when I ran the existing requirements file because of the `urllib3>=1.26.5`. I removed the version lock and this is what pip did and it worked.