### PR TITLE
fix requests dependency conflict with urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ certifi==2021.5.30
 chardet==3.0.4
 idna==2.10
 pick==1.0.0
-requests==2.24.0
+requests==2.26.0
 requests-toolbelt==0.9.1
 urllib3==1.26.6


### PR DESCRIPTION
Bump requests version to 2.26.0 to fix dependency conflict with urllib3 during installation of requirements:

> The user requested urllib3==1.26.6
> requests 2.24.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1

Tested that bumping up requests version resolves conflicts and allows pia-wg to run without issue.
Fixes #6 