### PR TITLE
Update generate-config.py, correct config format?

### DIFF
--- a/generate-config.py
+++ b/generate-config.py
@@ -40,7 +40,7 @@ config_file = 'PIA-{}-{}.conf'.format(location, timestamp)
 print("Saving configuration file {}".format(config_file))
 with open(config_file, 'w') as file:
     file.write('[Interface]\n')
-    file.write('Address = {}\n'.format(pia.connection['peer_ip']))
+    file.write('Address = {}/32\n'.format(pia.connection['peer_ip']))
     file.write('PrivateKey = {}\n'.format(pia.privatekey))
     file.write('DNS = {},{}\n\n'.format(pia.connection['dns_servers'][0], pia.connection['dns_servers'][1]))
     file.write('[Peer]\n')


### PR DESCRIPTION
My routers built in Wireguard refuse to load config if I don’t modify it so.

some other reference also suggest this is the correct format https://github.com/pirate/wireguard-docs#Address

I have zero knowledge in this, I don’t know if this change will cause other issues